### PR TITLE
More robust “tsc” during “build” lifecycle script using “npx”

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "postinstall": "npm run build",
     "cover": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
-    "build": "tsc -p tsconfig.json",
+    "build": "npx tsc -p tsconfig.json",
     "tslint": "tslint -c tslint.json src/**/*.ts",
     "test": "mocha src/**/*.spec.ts --recursive -c -r ts-node/register -R spec"
   },


### PR DESCRIPTION
When running `npm i` on a project that uses `simple-interpolation` as a dependency, I got this error:

```
sh: 1: tsc: not found
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! simple-interpolation@1.0.6 build: `tsc -p tsconfig.json`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the simple-interpolation@1.0.6 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/tripu/.npm/_cacache/_logs/2020-03-09T19_11_12_599Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! simple-interpolation@1.0.6 postinstall: `npm run build`
npm ERR! Exit status 1
```

This is (I believe) because TypeScript is not installed globally.

Running `tsc` through `npx` should solve this.

(While at it, I removed an empty file that afaict is not doing anything useful.)