### PR TITLE
Properly use the typescript npm package to run tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "postinstall": "npm run build",
     "prebuild": "rm -rf dist",
-    "build": "npx tsc",
+    "build": "npx -p typescript tsc",
     "lint": "eslint --ignore-path .eslintignore src/**/*.ts",
     "lint:fix": "eslint --ignore-path .eslintignore src/**/*.ts --fix",
     "test": "jest --coverage && coveralls < report/lcov.info",


### PR DESCRIPTION
Some builds that have simple-interpolation as a dependency are breaking because the user environment does not have a globally installed `tsc` command, and the `tsc` npm package is deprecated, which causes the `npx tsc` command to run a very old (1.5.3) typescript compiler that is unable to parse the `tsconfig` options in simple-interpolation.

Adding `-p typescript` while running `npx tsc` should solve the problem. Verified locally in my `node_modules/simple-interpolation` directory.